### PR TITLE
fix current state method.

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/execution/regex/FindFunctionExtension.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/regex/FindFunctionExtension.java
@@ -223,13 +223,11 @@ public class FindFunctionExtension extends FunctionExecutor {
 
     @Override
     public Map<String, Object> currentState() {
-        return new HashMap<String, Object>() {
-            {
-                put("isRegexConstant", isRegexConstant);
-                put("regexConstant", regexConstant);
-                put("patternConstant", patternConstant);
-            }
-        };
+        Map<String,Object> stateMap = new HashMap<>(3);
+        stateMap.put("isRegexConstant", isRegexConstant);
+        stateMap.put("regexConstant", regexConstant);
+        stateMap.put("patternConstant", patternConstant);
+        return stateMap;
     }
 
     @Override


### PR DESCRIPTION

## Purpose
Earlier currentState() implementation was returning an inner class of FunctionExtension extending HashMap. Because of this caller class identifies Object type as an Inner Class of FunctionExtension. This cause serialization to fail as FunctionExtension is not Serializable. 

## Goals
Create a new HashMap instance separately and return that.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
1.8.0
